### PR TITLE
Implement PPPoE Discovery.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module go.universe.tf/ppp
 
 require (
+	github.com/google/go-cmp v0.2.0
 	github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9
 	golang.org/x/net v0.0.0-20181108082009-03003ca0c849 // indirect
 	golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9 h1:tOtO8DXiNGj9NshRKHWiZuGlSldPFzFCFYhNtsKTBCs=
 github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9/go.mod h1:rC/yE65s/DoHB6BzVOUBNYBGTg772JVytyAytffIZkY=
 golang.org/x/net v0.0.0-20181108082009-03003ca0c849 h1:FSqE2GGG7wzsYUsWiQ8MZrvEd1EOyU3NCF0AW3Wtltg=

--- a/ppp/discovery.go
+++ b/ppp/discovery.go
@@ -2,8 +2,14 @@
 package ppp
 
 import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
+	"sort"
+	"time"
 
 	"github.com/mdlayher/raw"
 )
@@ -14,19 +20,35 @@ const (
 	protoPPPoESession   = 0x8864
 )
 
+// Constants for PPPoE Discovery packet types.
+const (
+	pppoePADI = 0x09 // "Hey, any PPPoE concentrators out there?
+	pppoePADO = 0x07 // "Hi, I'm a PPPoE concentrator"
+	pppoePADR = 0x19 // "Cool, can we set up a PPPoE session?"
+	pppoePADS = 0x65 // "Done, here's the session ID!"
+	pppoePADT = 0xa7 // "I'm tearing down our session"
+)
+
+// Constants for PPPoE Discovery tag types
+const (
+	pppoeTagServiceName = 0x0101 // Roughly speaking, the name of the ISP.
+	pppoeTagACName      = 0x0102 // Roughly speaking, the hostname of the PPPoE concentrator.
+	pppoeTagCookie      = 0x0104 // The PPPoE equivalent of a syncookie.
+)
+
 var (
 	// padiPacket is a PPPoE Active Discovery Initiation (PADI) packet
 	// that sollicits session offers from any available PPPoE
 	// concentrator.
-	padiPacket = []byte{
-		0x11, // Protocol version 1, packet type 1 (both constants)
-		9,    // Code PADI, aka "hey any PPPoE concentrators out there?"
-		0, 0, // Session ID, not set during discovery
-		0, 4, // Payload length. payload is a TLV array of tags, but we're sending only 1 zero-length tag
-		1, 1, // Tag "Service-Name", aka "which ISP is acceptable to me?
-		0, 0, // Tag value length, 0
-		// No tag value, meaning "any ISP is acceptable"
-	}
+	padiPacket = encodeDiscoveryPacket(&discoveryPacket{
+		Code: pppoePADI,
+		TLV: map[int][]byte{
+			// By convention on single-ISP customer access networks,
+			// the tag is always nil, meaning "don't care," because
+			// there's only one ISP around anyway.
+			pppoeTagServiceName: nil,
+		},
+	})
 	// ethernetBroadcast is the Ethernet broadcast address.
 	ethernetBroadcast = &raw.Addr{
 		HardwareAddr: net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
@@ -34,20 +56,267 @@ var (
 )
 
 // pppoeDiscovery executes PPPoE discovery and returns a PPPoE session ID.
-func pppoeDiscovery(ifName string) (sessionID uint16, err error) {
+func pppoeDiscovery(ctx context.Context, ifName string) (sessionID int, closer func() error, err error) {
+	conn, err := newDiscoveryConn(ifName)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
+
+	deadline, hasDeadline := ctx.Deadline()
+
+	var (
+		concentrator net.Addr
+		cookie       []byte
+	)
+
+	// Broadcast PADIs, looking for a PPPoE concentrator.
+	for concentrator == nil && (!hasDeadline || time.Now().Before(deadline)) {
+		// Send a PADI, asking concentrators for a session offer.
+		if err := sendPADI(conn); err != nil {
+			return 0, nil, fmt.Errorf("sending PADI packet: %v", err)
+		}
+
+		padoCtx, cancelPADO := context.WithTimeout(ctx, time.Second)
+		defer cancelPADO()
+		concentrator, cookie, err = readPADO(padoCtx, conn)
+		if err == nil {
+			// We know about a concentrator, move on.
+			break
+		} else if neterr, ok := err.(net.Error); !ok || !neterr.Timeout() {
+			return 0, nil, fmt.Errorf("waiting for PADO: %v", err)
+		}
+		// Timed out waiting for PADO. Loop back around to (maybe) try
+		// again.
+	}
+
+	// Got a concentrator, request a session.
+	for !hasDeadline || time.Now().Before(deadline) {
+		if err := sendPADR(conn, concentrator, cookie); err != nil {
+			return 0, nil, fmt.Errorf("sending PADR packet: %v", err)
+		}
+
+		padsCtx, cancelPADS := context.WithTimeout(ctx, time.Second)
+		defer cancelPADS()
+		sessionID, err = readPADS(padsCtx, conn, concentrator)
+		if err == nil {
+			// We're done!
+			return sessionID, func() error { return sendPADT(conn, concentrator, sessionID) }, nil
+		} else if neterr, ok := err.(net.Error); !ok || !neterr.Timeout() {
+			return 0, nil, fmt.Errorf("waiting for PADS: %v", err)
+		}
+		// Timed out waiting for PADS. Loop back around to (maybe) try
+		// again.
+	}
+
+	// Oops, deadline exceeded :(
+	return 0, nil, errors.New("deadline exceeded during PPPoE Discovery")
+}
+
+// newDiscoveryConn creates a net.PacketConn that can receive PPPoE
+// discovery packets.
+func newDiscoveryConn(ifName string) (net.PacketConn, error) {
 	intf, err := net.InterfaceByName(ifName)
 	if err != nil {
-		return 0, fmt.Errorf("getting interface: %v", err)
+		return nil, fmt.Errorf("getting interface %v: %v", ifName, err)
 	}
 	conn, err := raw.ListenPacket(intf, protoPPPoEDiscovery, &raw.Config{LinuxSockDGRAM: true})
 	if err != nil {
-		return 0, fmt.Errorf("creating PPPoE Discovery listener: %v", err)
+		return nil, fmt.Errorf("creating PPPoE Discovery listener: %v", err)
 	}
-	defer conn.Close()
+	return conn, nil
+}
 
-	if _, err := conn.WriteTo(padiPacket, ethernetBroadcast); err != nil {
-		return 0, fmt.Errorf("sending PADI packet: %v", err)
+// sendPADI broadcasts a PADI packet. While trivial, it's separated
+// out so tests can invoke it.
+func sendPADI(conn net.PacketConn) error {
+	_, err := conn.WriteTo(padiPacket, ethernetBroadcast)
+	return err
+}
+
+// readPADO waits to receive a valid PPPoE Active Discovery Offer
+// (PADO) packet, and returns relevant information from it.
+func readPADO(ctx context.Context, conn net.PacketConn) (concentratorAddr net.Addr, cookie []byte, err error) {
+	var b [1500]byte
+
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetReadDeadline(deadline)
+		defer conn.SetReadDeadline(time.Time{})
+	}
+	for {
+		n, from, err := conn.ReadFrom(b[:])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		cookie, err := parsePADO(b[:n])
+		if err == nil {
+			return from, cookie, nil
+		}
+
+		// Not a valid PADO, keep waiting
+	}
+}
+
+// parsePADO parses a raw PADO packet and extracts the PPPoE cookie.
+func parsePADO(buf []byte) (cookie []byte, err error) {
+	pkt, err := parseDiscoveryPacket(buf)
+	if err != nil {
+		return nil, err
+	}
+	if pkt.Code != pppoePADO {
+		return nil, errors.New("not a PADO packet")
+	}
+	if pkt.SessionID != 0 {
+		return nil, errors.New("non-zero session ID")
 	}
 
-	panic("TODO")
+	// Note, not having a cookie is fine. Its function is similar to
+	// syncookies, an anti-DoS measure at the concentrator. If the
+	// concentrator doesn't care, then neither do we.
+	return pkt.TLV[pppoeTagCookie], nil
+}
+
+func sendPADR(conn net.PacketConn, concentrator net.Addr, cookie []byte) error {
+	pkt := &discoveryPacket{
+		Code: pppoePADR,
+		TLV: map[int][]byte{
+			pppoeTagServiceName: nil,
+		},
+	}
+	if len(cookie) != 0 {
+		pkt.TLV[pppoeTagCookie] = cookie
+	}
+	_, err := conn.WriteTo(encodeDiscoveryPacket(pkt), concentrator)
+	return err
+}
+
+func readPADS(ctx context.Context, conn net.PacketConn, concentrator net.Addr) (sessionID int, err error) {
+	var b [1500]byte
+
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetReadDeadline(deadline)
+		defer conn.SetReadDeadline(time.Time{})
+	}
+	for {
+		n, from, err := conn.ReadFrom(b[:])
+		if err != nil {
+			return 0, err
+		}
+
+		if concentrator.String() != from.String() {
+			// Wrong peer, keep waiting
+			continue
+		}
+
+		sessionID, err = parsePADS(b[:n])
+		if err == nil {
+			return sessionID, nil
+		}
+
+		// Not a valid PADO, keep waiting
+	}
+}
+
+func parsePADS(buf []byte) (sessionID int, err error) {
+	pkt, err := parseDiscoveryPacket(buf)
+	if err != nil {
+		return 0, err
+	}
+	if pkt.Code != pppoePADS {
+		return 0, errors.New("not a PADS packet")
+	}
+	return pkt.SessionID, nil
+}
+
+func sendPADT(conn net.PacketConn, concentrator net.Addr, sessionID int) error {
+	pkt := &discoveryPacket{
+		Code:      pppoePADT,
+		SessionID: sessionID,
+	}
+	_, err := conn.WriteTo(encodeDiscoveryPacket(pkt), concentrator)
+	conn.Close()
+	return err
+}
+
+// discoveryPacket is a parsed PPPoE Discovery packet.
+type discoveryPacket struct {
+	Code      int
+	SessionID int
+	TLV       map[int][]byte
+}
+
+// parseDiscoveryPacket parses a PPPoE Discovery packet into a discoveryPacket.
+func parseDiscoveryPacket(pkt []byte) (*discoveryPacket, error) {
+	if len(pkt) < 6 {
+		return nil, errors.New("packet too short to be PPPoE Discovery")
+	}
+	if pkt[0] != 0x11 {
+		return nil, fmt.Errorf("unknown PPPoE version %x", pkt[0])
+	}
+
+	ret := &discoveryPacket{
+		Code:      int(pkt[1]),
+		SessionID: int(binary.BigEndian.Uint16(pkt[2:4])),
+		TLV:       map[int][]byte{},
+	}
+
+	tlvLen := int(binary.BigEndian.Uint16(pkt[4:6]))
+	pkt = pkt[6:]
+	if tlvLen != len(pkt) {
+		return nil, fmt.Errorf("Tag array length %v doesn't match remaining packet length %v", tlvLen, len(pkt))
+	}
+
+	for len(pkt) > 0 {
+		if len(pkt) < 4 {
+			return nil, fmt.Errorf("%d bytes of trailing garbage at end of packet", len(pkt))
+		}
+
+		tagType, tagLen := int(binary.BigEndian.Uint16(pkt[:2])), int(binary.BigEndian.Uint16(pkt[2:4]))
+		if len(pkt[4:]) < tagLen {
+			return nil, errors.New("tag declared length larger than remaining packet")
+		}
+
+		tagValue := pkt[4 : 4+tagLen]
+		pkt = pkt[4+tagLen:]
+
+		if tagType == pppoeTagServiceName && tagLen != 0 {
+			return nil, errors.New("unexpected non-nil Service-Name tag")
+		}
+
+		ret.TLV[tagType] = tagValue
+	}
+
+	return ret, nil
+}
+
+// encodeDiscoveryPacket marshals a PPPoE Discovery packet into raw bytes.
+func encodeDiscoveryPacket(pkt *discoveryPacket) []byte {
+	tlvLen, tlvs := 0, []int{}
+	for tlv, val := range pkt.TLV {
+		tlvs = append(tlvs, tlv)
+		tlvLen += len(val)
+	}
+	sort.Ints(tlvs)
+
+	var ret bytes.Buffer
+	ret.Write([]byte{
+		0x11,            // Protocol version 1, packet type 1 (both constants)
+		uint8(pkt.Code), // PPPoE packet code
+	})
+	binary.Write(&ret, binary.BigEndian, uint16(pkt.SessionID))
+	binary.Write(&ret, binary.BigEndian, uint16(tlvLen+(4*len(pkt.TLV))))
+
+	for _, tlv := range tlvs {
+		val := pkt.TLV[tlv]
+		binary.Write(&ret, binary.BigEndian, uint16(tlv))
+		binary.Write(&ret, binary.BigEndian, uint16(len(val)))
+		ret.Write(val)
+	}
+
+	return ret.Bytes()
 }

--- a/ppp/discovery_test.go
+++ b/ppp/discovery_test.go
@@ -1,0 +1,218 @@
+package ppp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDiscovery(t *testing.T) {
+	if err := canTest(); err != nil {
+		t.Skipf("can't run privileged tests: %v", err)
+	}
+
+	close, err := startServer()
+	if err != nil {
+		t.Fatalf("couldn't start pppd container: %v", err)
+	}
+	defer close()
+
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	_, sendPADT, err := pppoeDiscovery(ctx, "docker0")
+	if err != nil {
+		t.Fatalf("PPPoE discovery failed: %v", err)
+	}
+	defer sendPADT()
+}
+
+func TestParseDiscoveryPacket(t *testing.T) {
+	tests := []struct {
+		desc        string
+		raw         []byte
+		want        *discoveryPacket
+		wantErr     bool
+		skipUnparse bool
+	}{
+		{
+			desc: "PADO",
+			raw:  []byte{0x11, 7, 0, 0, 0, 4, 1, 1, 0, 0},
+			want: &discoveryPacket{
+				Code: 7,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+				},
+			},
+		},
+		{
+			desc: "PADO with cookie",
+			raw:  []byte{0x11, 7, 0, 0, 0, 11, 1, 1, 0, 0, 1, 4, 0, 3, 'N', 'O', 'M'},
+			want: &discoveryPacket{
+				Code: 7,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+					pppoeTagCookie:      []byte("NOM"),
+				},
+			},
+		},
+
+		{
+			desc: "PADS",
+			raw:  []byte{0x11, 0x65, 0x42, 0x43, 0, 4, 1, 1, 0, 0},
+			want: &discoveryPacket{
+				Code:      0x65,
+				SessionID: 0x4243,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+				},
+			},
+		},
+
+		{
+			desc:    "short",
+			raw:     []byte{0x11},
+			wantErr: true,
+		},
+		{
+			desc:    "not pppoe",
+			raw:     []byte{0, 0, 0, 0, 0, 0, 0, 0, 0},
+			wantErr: true,
+		},
+		{
+			desc:    "short TLV array length",
+			raw:     []byte{0x11, 7, 0, 0, 0, 2, 1, 1, 0, 0},
+			wantErr: true,
+		},
+		{
+			desc:    "long TLV array length",
+			raw:     []byte{0x11, 7, 0, 0, 200, 200, 1, 1, 0, 0},
+			wantErr: true,
+		},
+		{
+			desc:    "TLV trailing garbage",
+			raw:     []byte{0x11, 7, 0, 0, 0, 5, 1, 1, 0, 0, 0},
+			wantErr: true,
+		},
+		{
+			desc:    "wrong service name",
+			raw:     []byte{0x11, 7, 0, 0, 0, 5, 1, 1, 0, 1, 'A'},
+			wantErr: true,
+		},
+		{
+			desc:    "overflowing TLV",
+			raw:     []byte{0x11, 7, 0, 0, 0, 4, 1, 1, 200, 200},
+			wantErr: true,
+		},
+
+		// These are some real packets, stolen from real ISP
+		// handshakes.
+		{
+			desc: "real isp PADI",
+			raw:  []byte{0x11, 0x09, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01, 0x00, 0x00},
+			want: &discoveryPacket{
+				Code: 0x09,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+				},
+			},
+		},
+		{
+			desc: "real isp PADO",
+			raw: []byte{
+				0x11, 0x07, 0x00, 0x00, 0x00, 0x38, 0x01, 0x02, 0x00, 0x1c,
+				0x74, 0x75, 0x6b, 0x77, 0x2d, 0x64, 0x73, 0x6c, 0x2d, 0x67,
+				0x77, 0x30, 0x31, 0x2e, 0x74, 0x75, 0x6b, 0x77, 0x2e, 0x71,
+				0x77, 0x65, 0x73, 0x74, 0x2e, 0x6e, 0x65, 0x74, 0x01, 0x01,
+				0x00, 0x00, 0x01, 0x04, 0x00, 0x10, 0x64, 0xb1, 0x40, 0x19,
+				0xe3, 0x6e, 0x03, 0xb6, 0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88,
+				0x34, 0xdb,
+			},
+			want: &discoveryPacket{
+				Code:      0x07,
+				SessionID: 0,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+					pppoeTagACName:      []byte("tukw-dsl-gw01.tukw.qwest.net"),
+					pppoeTagCookie: []byte{
+						0x64, 0xb1, 0x40, 0x19, 0xe3, 0x6e, 0x03, 0xb6,
+						0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88, 0x34, 0xdb,
+					},
+				},
+			},
+			skipUnparse: true, // Not idempotent due to ordering of TLVs
+		},
+		{
+			desc: "real isp PADR",
+			raw: []byte{
+				0x11, 0x19, 0x00, 0x00, 0x00, 0x18, 0x01, 0x01, 0x00, 0x00,
+				0x01, 0x04, 0x00, 0x10, 0x64, 0xb1, 0x40, 0x19, 0xe3, 0x6e,
+				0x03, 0xb6, 0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88, 0x34, 0xdb,
+			},
+			want: &discoveryPacket{
+				Code:      0x19,
+				SessionID: 0,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+					pppoeTagCookie: []byte{
+						0x64, 0xb1, 0x40, 0x19, 0xe3, 0x6e, 0x03, 0xb6,
+						0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88, 0x34, 0xdb,
+					},
+				},
+			},
+		},
+		{
+			desc: "real isp PADS",
+			raw: []byte{
+				0x11, 0x65, 0x01, 0xeb, 0x00, 0x38, 0x01, 0x01, 0x00, 0x00,
+				0x01, 0x02, 0x00, 0x1c, 0x74, 0x75, 0x6b, 0x77, 0x2d, 0x64,
+				0x73, 0x6c, 0x2d, 0x67, 0x77, 0x30, 0x31, 0x2e, 0x74, 0x75,
+				0x6b, 0x77, 0x2e, 0x71, 0x77, 0x65, 0x73, 0x74, 0x2e, 0x6e,
+				0x65, 0x74, 0x01, 0x04, 0x00, 0x10, 0x64, 0xb1, 0x40, 0x19,
+				0xe3, 0x6e, 0x03, 0xb6, 0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88,
+				0x34, 0xdb,
+			},
+			want: &discoveryPacket{
+				Code:      0x65,
+				SessionID: 0x01eb,
+				TLV: map[int][]byte{
+					pppoeTagServiceName: []byte{},
+					pppoeTagACName:      []byte("tukw-dsl-gw01.tukw.qwest.net"),
+					pppoeTagCookie: []byte{
+						0x64, 0xb1, 0x40, 0x19, 0xe3, 0x6e, 0x03, 0xb6,
+						0x5c, 0x2f, 0xdb, 0x9e, 0x63, 0x88, 0x34, 0xdb,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got, gotErr := parseDiscoveryPacket(test.raw)
+			if gotErr != nil && !test.wantErr {
+				t.Fatalf("unexpected error %v", gotErr)
+			} else if gotErr == nil && test.wantErr {
+				t.Fatalf("unexpected success")
+			}
+			if test.wantErr {
+				return
+			}
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Fatalf("wrong parse: (-want +got)\n%s", diff)
+			}
+
+			// Also test that we can unparse the parsed packet back
+			// into their original form.
+			if !test.skipUnparse {
+				gotRaw := encodeDiscoveryPacket(got)
+				if diff := cmp.Diff(test.raw, gotRaw); diff != "" {
+					t.Fatalf("wrong unparse: (-want, +got)\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/ppp/discovery_test.go
+++ b/ppp/discovery_test.go
@@ -42,7 +42,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			raw:  []byte{0x11, 7, 0, 0, 0, 4, 1, 1, 0, 0},
 			want: &discoveryPacket{
 				Code: 7,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 				},
 			},
@@ -52,7 +52,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			raw:  []byte{0x11, 7, 0, 0, 0, 11, 1, 1, 0, 0, 1, 4, 0, 3, 'N', 'O', 'M'},
 			want: &discoveryPacket{
 				Code: 7,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 					pppoeTagCookie:      []byte("NOM"),
 				},
@@ -65,7 +65,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			want: &discoveryPacket{
 				Code:      0x65,
 				SessionID: 0x4243,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 				},
 			},
@@ -82,17 +82,17 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:    "short TLV array length",
+			desc:    "short Tags array length",
 			raw:     []byte{0x11, 7, 0, 0, 0, 2, 1, 1, 0, 0},
 			wantErr: true,
 		},
 		{
-			desc:    "long TLV array length",
+			desc:    "long Tags array length",
 			raw:     []byte{0x11, 7, 0, 0, 200, 200, 1, 1, 0, 0},
 			wantErr: true,
 		},
 		{
-			desc:    "TLV trailing garbage",
+			desc:    "Tags trailing garbage",
 			raw:     []byte{0x11, 7, 0, 0, 0, 5, 1, 1, 0, 0, 0},
 			wantErr: true,
 		},
@@ -102,7 +102,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc:    "overflowing TLV",
+			desc:    "overflowing Tags",
 			raw:     []byte{0x11, 7, 0, 0, 0, 4, 1, 1, 200, 200},
 			wantErr: true,
 		},
@@ -114,7 +114,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			raw:  []byte{0x11, 0x09, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01, 0x00, 0x00},
 			want: &discoveryPacket{
 				Code: 0x09,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 				},
 			},
@@ -133,7 +133,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			want: &discoveryPacket{
 				Code:      0x07,
 				SessionID: 0,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 					pppoeTagACName:      []byte("tukw-dsl-gw01.tukw.qwest.net"),
 					pppoeTagCookie: []byte{
@@ -142,7 +142,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 					},
 				},
 			},
-			skipUnparse: true, // Not idempotent due to ordering of TLVs
+			skipUnparse: true, // Not idempotent due to ordering of Tags
 		},
 		{
 			desc: "real isp PADR",
@@ -154,7 +154,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			want: &discoveryPacket{
 				Code:      0x19,
 				SessionID: 0,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 					pppoeTagCookie: []byte{
 						0x64, 0xb1, 0x40, 0x19, 0xe3, 0x6e, 0x03, 0xb6,
@@ -177,7 +177,7 @@ func TestParseDiscoveryPacket(t *testing.T) {
 			want: &discoveryPacket{
 				Code:      0x65,
 				SessionID: 0x01eb,
-				TLV: map[int][]byte{
+				Tags: map[int][]byte{
 					pppoeTagServiceName: []byte{},
 					pppoeTagACName:      []byte("tukw-dsl-gw01.tukw.qwest.net"),
 					pppoeTagCookie: []byte{

--- a/ppp/ppp_test.go
+++ b/ppp/ppp_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os/exec"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/mdlayher/raw"
@@ -73,18 +72,4 @@ func startServer() (func(), error) {
 	}
 
 	return closeFunc, nil
-}
-
-func TestDiscovery(t *testing.T) {
-	if err := canTest(); err != nil {
-		t.Skipf("can't run privileged tests: %v", err)
-	}
-
-	close, err := startServer()
-	if err != nil {
-		t.Fatalf("couldn't start pppd container: %v", err)
-	}
-	defer close()
-
-	pppoeDiscovery("docker0")
 }


### PR DESCRIPTION
The API is still private, and has the wrong shape to function nicely
with upper level protocols (e.g. there needs to be a way to deliver an
asynchronous PADT to the PPP layer), but it passes tests against a real
PPPoE server, so that's nice.