### PR TITLE
Move current code to internal/pppoe.

### DIFF
--- a/internal/pppoe/discovery.go
+++ b/internal/pppoe/discovery.go
@@ -1,5 +1,5 @@
-// Package ppp establishes a PPP connection running over PPPoE.
-package ppp
+// Package pppoe creates a PPPoE session with a remote server.
+package pppoe
 
 import (
 	"bytes"

--- a/internal/pppoe/discovery_test.go
+++ b/internal/pppoe/discovery_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDiscovery(t *testing.T) {
-	if err := testutil.CanRunPrivilegedTests(); err != nil {
+	if err := testutil.CheckPrivilegeForContainerTests(); err != nil {
 		t.Skipf("can't run privileged tests: %v", err)
 	}
 

--- a/internal/pppoe/discovery_test.go
+++ b/internal/pppoe/discovery_test.go
@@ -1,4 +1,4 @@
-package ppp
+package pppoe
 
 import (
 	"context"
@@ -6,14 +6,16 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
+	"go.universe.tf/ppp/internal/testutil"
 )
 
 func TestDiscovery(t *testing.T) {
-	if err := canTest(); err != nil {
+	if err := testutil.CanRunPrivilegedTests(); err != nil {
 		t.Skipf("can't run privileged tests: %v", err)
 	}
 
-	close, err := startServer()
+	close, err := testutil.StartServer()
 	if err != nil {
 		t.Fatalf("couldn't start pppd container: %v", err)
 	}

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -1,4 +1,4 @@
-// package testutil contains some helpers for testing PPP and PPPoE connections.
+// Package testutil contains some helpers for testing PPP and PPPoE connections.
 package testutil
 
 import (
@@ -29,8 +29,8 @@ func canUseRawSockets() error {
 	return nil
 }
 
-// CanRunPrivilegedTests returns nil if Docker and raw socket based tests can be run.
-func CanRunPrivilegedTests() error {
+// CheckPrivilegeForContainerTests returns nil if Docker and raw socket based tests can be run.
+func CheckPrivilegeForContainerTests() error {
 	if err := canUseRawSockets(); err != nil {
 		return err
 	}
@@ -40,9 +40,9 @@ func CanRunPrivilegedTests() error {
 	return nil
 }
 
-// StartServer runs a PPP+PPPoE server in a Docker container. Returns
-// a closer function (which should be defer-ed), or an error if server
-// startup fails.
+// StartServer runs a PPP+PPPoE server in a Docker container. It
+// returns a closer function (which should be defer-ed), or an error
+// if server startup fails.
 func StartServer() (func(), error) {
 	if err := canUseDocker(); err != nil {
 		return nil, fmt.Errorf("can't run docker: %v", err)

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -1,5 +1,5 @@
-// package ppp implements establishing a PPP connection running over PPPoE.
-package ppp
+// package testutil contains some helpers for testing PPP and PPPoE connections.
+package testutil
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ func canUseRawSockets() error {
 	if err != nil {
 		return fmt.Errorf("getting interface: %v", err)
 	}
-	conn, err := raw.ListenPacket(intf, protoPPPoEDiscovery, &raw.Config{LinuxSockDGRAM: true})
+	conn, err := raw.ListenPacket(intf, 0x8863, &raw.Config{LinuxSockDGRAM: true})
 	if err != nil {
 		return fmt.Errorf("creating PPPoE Discovery listener: %v", err)
 	}
@@ -29,7 +29,8 @@ func canUseRawSockets() error {
 	return nil
 }
 
-func canTest() error {
+// CanRunPrivilegedTests returns nil if Docker and raw socket based tests can be run.
+func CanRunPrivilegedTests() error {
 	if err := canUseRawSockets(); err != nil {
 		return err
 	}
@@ -39,7 +40,10 @@ func canTest() error {
 	return nil
 }
 
-func startServer() (func(), error) {
+// StartServer runs a PPP+PPPoE server in a Docker container. Returns
+// a closer function (which should be defer-ed), or an error if server
+// startup fails.
+func StartServer() (func(), error) {
 	if err := canUseDocker(); err != nil {
 		return nil, fmt.Errorf("can't run docker: %v", err)
 	}


### PR DESCRIPTION
Also create a testutil internal package to handle all the docker
nonsense for future packages.