### PR TITLE
Bind the PPPoE session to a PPP generic channel.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/google/go-cmp v0.2.0
 	github.com/mdlayher/raw v0.0.0-20181016155347-fa5ef3332ca9
 	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect
-	golang.org/x/sys v0.0.0-20181116161606-93218def8b18
+	golang.org/x/sys v0.0.0-20181119195503-ec83556a53fe
 )

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8 h1:YoY1wS6JYVRpIfFngRf2HHo9R
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116161606-93218def8b18 h1:Wh+XCfg3kNpjhdq2LXrsiOProjtQZKme5XUx7VcxwAw=
 golang.org/x/sys v0.0.0-20181116161606-93218def8b18/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181119195503-ec83556a53fe h1:I5KvcSfxR/TkvFksuALBTCS44kh6MaPO1rHR9vT0iQQ=
+golang.org/x/sys v0.0.0-20181119195503-ec83556a53fe/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This seems to be necessary to receive packets. It's
also a required step on the road of getting full PPP
working, so it's not much hardship to just do it now.

As a bonus, it lets us piggyback on os.File for a bunch
of fiddly things like deadlines.

PPPoE test now passes with reading and writing of control
packets.